### PR TITLE
Fix for compilation error issue5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .gcc-flags.json
 
 Air/Air.ino.cpp
+lib/Device/Device.h
 
+.DS_Store
 .vscode
 data/

--- a/platformio.ini
+++ b/platformio.ini
@@ -37,7 +37,7 @@ lib_deps=
   Wire @ 1.0
   SPI @ 1.0
   OneWire@2.3.4
-  ArduinoJson@6.10.0
+  ArduinoJson@6.10.1
   NTPClient@3.1.0
 
 [env:nodemcu]


### PR DESCRIPTION
Hi,

This PR is to resolve issue #5 on the tracker, caused by an outdated ArduinoJson library (6.10.0). Although the current 6.18.0 version of that library seems to work well here, I've updated minimally to 6.10.1, where this bug was resolved by the library maintainer, to avoid any unforeseen issues.

As a bonus I've updated .gitignore to include .DS_Store system file on macOS and also lib/Device/Device.h as that should always be user-specific.

Hope this helps a bit!
